### PR TITLE
Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install rgbds
+        run: |
+          mkdir /tmp/rgbds
+          cd /tmp
+          wget https://github.com/gbdev/rgbds/releases/download/v0.9.2/rgbds-0.9.2-linux-x86_64.tar.xz
+          tar xf rgbds-0.9.2-linux-x86_64.tar.xz -C rgbds
+          cd rgbds
+          sudo ./install.sh
+      - name: Build ROM
+        run: make
+      - name: Upload ROM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-gb
+          path: main.gb


### PR DESCRIPTION
## Summary
- add a workflow that runs on `master` pushes and PRs
- install `rgbds` via official release tarball
- build the ROM and upload `main.gb` as an artifact
- use `actions/checkout@v4` and `actions/upload-artifact@v4`

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_68597a3c9d908333bde94ba270ad0811