### PR TITLE
Add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install rgbds
+        run: |
+          mkdir /tmp/rgbds
+          cd /tmp
+          wget https://github.com/gbdev/rgbds/releases/download/v0.9.2/rgbds-0.9.2-linux-x86_64.tar.xz
+          tar xf rgbds-0.9.2-linux-x86_64.tar.xz -C rgbds
+          cd rgbds
+          sudo ./install.sh
+      - name: Build ROM
+        run: make
+      - name: Determine if tag is on master
+        id: prerelease
+        run: |
+          git fetch origin master
+          if git merge-base --is-ancestor HEAD origin/master; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: main.gb
+          generate_release_notes: true
+          prerelease: ${{ steps.prerelease.outputs.prerelease }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- automate building when tags are pushed and generate release notes
- mark releases as prereleases when tag isn't on master

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_685b0acc4a288333b911dfe675fbd2ae